### PR TITLE
Enhance order status handling and UI in customer pages

### DIFF
--- a/src/app/(default-layout)/(customer)/cartpage/page.tsx
+++ b/src/app/(default-layout)/(customer)/cartpage/page.tsx
@@ -576,19 +576,6 @@ export default function CartPage() {
                       </span>
                     </Button>
                     
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        // Select only first item for testing
-                        if (cart.items.length > 0) {
-                          setSelectedProductIds([cart.items[0].productId._id]);
-                        }
-                      }}
-                      className="text-xs"
-                    >
-                      Test: Select First Only
-                    </Button>
                   </div>
                   <span className="text-sm text-gray-500">
                     {selectedProductIds.length} of {cart.items.length} selected


### PR DESCRIPTION
Removed test button from cart page. Improved myorders page by adding support for displaying rejected and refunded orders directly from the orders API, updating tab counts, and introducing dedicated UI components for rejected and refunded orders. Also added 'intransit' status handling for shipping logs, including progress indicators and badge styling.